### PR TITLE
Retry web UI launch with share flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ You will need Python installed. I document what version I normally use in .pytho
    ```bash
    ./novelai.sh
    ```
+   - If the UI fails to launch because `localhost` isn't accessible, re-run with the `--share` flag to generate a public link.
+   ```bash
+   ./novelai.sh start --share
+   ```
    ```cmd
    novelai.bat
    ```

--- a/main.py
+++ b/main.py
@@ -327,7 +327,15 @@ def startapp(inbrowser, port, share):
                     #         fn=lambda:
                     #     )
     # Launch app!
-    appuiblocks.launch(server_port=int(port), show_error=True, share=share, inbrowser=inbrowser, show_api=False)
+    try:
+        appuiblocks.launch(server_port=int(port), show_error=True, share=share, inbrowser=inbrowser, show_api=False)
+    except ValueError as e:
+        if not share and "shareable link" in str(e):
+            print("Warning:", e)
+            print("Retrying with share=True to create a public link...")
+            appuiblocks.launch(server_port=int(port), show_error=True, share=True, inbrowser=inbrowser, show_api=False)
+        else:
+            raise
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
## Summary
- auto-retry gradio launch with `share=True` if `localhost` isn't accessible

## Testing
- `pytest --maxfail=1 -q` *(fails: pyenv pytest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce4e88388832f9d4c8ff048a02957