### PR TITLE
Fix Gradio API info crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,6 +60,11 @@ def start(
 
 def startapp(inbrowser, port, share):
     import gradio as gr
+    # Gradio 5.9.1 can fail when building API information if any schema
+    # contains boolean `additionalProperties` values.  The web UI does not
+    # require the API docs, so bypass the call entirely to avoid a crash.
+    import gradio.blocks as gr_blocks
+    gr_blocks.Blocks.get_api_info = lambda self: {}
     with gr.Blocks() as appuiblocks:
         # Generate Novel
         with gr.Tabs():


### PR DESCRIPTION
## Summary
- patch `startapp` to skip `Blocks.get_api_info`

## Testing
- `python3 -m py_compile main.py openaiapp.py functions.py config.py audioapp.py booksapp.py chaptersapp.py`

------
https://chatgpt.com/codex/tasks/task_e_685cecc05be4832f926cb7b5f7074740